### PR TITLE
[PV-246] Devops implementation - requirements don't work in checks, w…

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.10]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
…rong Python version?

Simple change to django.yml to specify 3.10 for Python.  I think i have tested using my local Docker set up (but not 100% sure!)