### PR TITLE
[PV-246] Devops implementation - requirements don't work in checks

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.10]
+        python-version: ['3.10']
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
…rong Python version?

Added quotes to 3.10 as was interpreting as 3.1 during checks on Github.