### PR TITLE
Fix tests working from command line

### DIFF
--- a/plan_visual_django/tests/test_api/test_get_plan_data.py
+++ b/plan_visual_django/tests/test_api/test_get_plan_data.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from ddt import ddt
 from django.test import TestCase
 from plan_visual_django.models import PlanField
-from resources.test_configuration import test_fixtures_folder, test_data_base_folder
+from plan_visual_django.tests.resources.test_configuration import test_fixtures_folder, test_data_base_folder
 
 test_plan_data = [
     ("001", "activity-01", 5, datetime(year=2021, month=11, day=30), datetime(year=2021, month=12, day=4), 1)

--- a/plan_visual_django/tests/test_file_import/test_file_read_and_parse.py
+++ b/plan_visual_django/tests/test_file_import/test_file_read_and_parse.py
@@ -15,7 +15,7 @@ from plan_visual_django.models import Plan, FileType
 from plan_visual_django.services.plan_file_utilities.plan_parsing import read_and_parse_plan
 from plan_visual_django.services.plan_file_utilities.plan_reader import ExcelXLSFileReader
 from plan_visual_django.tests.test_settings import EXCEL_PLAN_FILE_FOLDER
-from resources.test_configuration import test_data_base_folder, test_fixtures_folder
+from plan_visual_django.tests.resources.test_configuration import test_data_base_folder, test_fixtures_folder
 
 
 @ddt

--- a/plan_visual_django/tests/test_file_import/test_technical_file_read.py
+++ b/plan_visual_django/tests/test_file_import/test_technical_file_read.py
@@ -15,7 +15,7 @@ from django.test import TestCase
 from plan_visual_django.services.plan_file_utilities.plan_reader import ExcelXLSFileReader
 from plan_visual_django.tests.test_settings import EXCEL_PLAN_FILE_FOLDER
 from plan_visual_django.tests.utilities import date_from_string
-from resources.test_configuration import test_data_base_folder, test_fixtures_folder
+from plan_visual_django.tests.resources.test_configuration import test_data_base_folder, test_fixtures_folder
 
 # Define input file paramters and expected results separately as we may want the same data in various different input
 # file variants (e.g. sheet name different), but the expected results will be the same - we don't want to have to copy

--- a/plan_visual_django/tests/test_models/test_plan_activity.py
+++ b/plan_visual_django/tests/test_models/test_plan_activity.py
@@ -7,7 +7,7 @@ from unittest import skip
 from ddt import ddt, data, unpack
 from django.test import TestCase
 from plan_visual_django.models import PlanFieldMappingType, PlanMappedField, PlanField
-from resources.test_configuration import test_data_base_folder, test_fixtures_folder
+from plan_visual_django.tests.resources.test_configuration import test_data_base_folder, test_fixtures_folder
 
 # Data for different field mapping schemas to test completeness validation
 plan_mapped_field_data_cases = [

--- a/plan_visual_django/tests/test_models/test_plan_field.py
+++ b/plan_visual_django/tests/test_models/test_plan_field.py
@@ -7,8 +7,8 @@ from ddt import ddt, data, unpack
 from django.test import TestCase
 
 from plan_visual_django.models import PlanField
-from resources.test_configuration import test_data_base_folder, test_fixtures_folder
-from resources.utilities import generate_test_data_field_stream
+from plan_visual_django.tests.resources.test_configuration import test_data_base_folder, test_fixtures_folder
+from plan_visual_django.tests.resources.utilities import generate_test_data_field_stream
 
 
 @ddt


### PR DESCRIPTION
Import statements didn't work for some of the tests, probably because tests run from different home directory when run using manage.py test.  Easy to update by using full namespace qualifier from root of project.